### PR TITLE
Add all of the templates

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Code of Conduct
+
+As contributors and maintainers of this project, we pledge to follow the [Contributor Covenant](https://www.contributor-covenant.org/) in our interactions with others. We value an open and welcoming environment where everyone feels respected and heard.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Being respectful and considerate of differing viewpoints.
+- Using welcoming and inclusive language.
+- Focusing on what is best for the community.
+- Showing empathy towards other community members.
+
+Examples of unacceptable behavior include:
+
+- Harassment, trolling, or derogatory comments.
+- Personal attacks or insults.
+- Any form of discrimination.
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of behavior. They have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned with this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team. The project team will review and address any reported issues promptly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Before you start contributing to the code, please take a moment to review the fo
 ## How to Contribute
 
 1. **Create a branch**
-   - Create a new branch based on the `main` branch
+   - Create a new branch based off the latest version of the `main` branch
 
 3. **Make changes**
    - Make your desired changes (bug fixes, new features, documentation updates, etc.)
@@ -36,6 +36,7 @@ Before you start contributing to the code, please take a moment to review the fo
    - Push your changes
    - Open a PR against the `main` branch of this repository
    - Follow the template to create a detailed description of your changes
+   - Once approved, you may merge the PR by squashing the commits into a single PR commit
 
 ## Code of Conduct
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to Almost yellow
+
+## Table of Contents
+
+- Getting Started
+- How to Contribute
+- Code of Conduct
+- License
+
+## Getting Started
+
+Before you start contributing to the code, please take a moment to review the following resources:
+
+- Project README: Make sure you can set up and run the project and tests locally.
+- Issues: Check existing issues to see if there are any open tasks relating to what you plan to do.
+
+## How to Contribute
+
+1. **Create a branch**
+   - Create a new branch based on the `main` branch
+
+3. **Make changes**
+   - Make your desired changes (bug fixes, new features, documentation updates, etc.)
+   - Write clear commit messages that describe your changes
+   - Keep scripts short and break out separate components where possible
+
+4. **Test your changes**
+   - Ensure that your changes work as expected in your local environment using `npm run dev`
+   - Make sure the changes build using `npm run build`
+   - Run the playwright tests `npx playwright test`
+   - Run the linting script `npm run lint`
+   - Resolve any errors that you find and repeat until tests and linting all pass
+   - If you haven't already, consider adding additional playwright tests for your changes
+
+5. **Submit a Pull Request (PR)**
+   - Push your changes
+   - Open a PR against the `main` branch of this repository
+   - Follow the template to create a detailed description of your changes
+
+## Code of Conduct
+
+Please note that we have a [Code of Conduct](https://github.com/cjrace/almostyellow?tab=coc-ov-file) in place. By participating in this project, you agree to abide by its terms.
+
+## License
+
+Almost yellow is open-source software released under the MIT License.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Overview of changes
+
+<!-- Briefly describe the purpose of this pull request. -->
+
+## List of changes
+
+<!-- List the changes made in this PR. -->
+
+
+## Related issues
+
+<!-- LIf this PR is related to any existing issues, mention them here (e.g., "Fixes #123"). -->
+
+## Screenshots (if applicable)
+
+<!-- Add any relevant screenshots or images, including before and after if possible. -->
+
+## Additional notes
+
+<!-- Any additional context or information. -->
+
+## Checklist
+- [ ] I have tested these changes locally using `npm run build` and `npx run playwright`
+- [ ] I have updated the documentation (if needed)
+- [ ] I have added or updated tests for these changes (if applicable)
+
+## Reviewer instructions
+
+<!-- Put any specific questions or instructions for reviewers in here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,22 +2,9 @@
 
 <!-- Briefly describe the purpose of this pull request. -->
 
-## List of changes
-
-<!-- List the changes made in this PR. -->
-
-
-## Related issues
-
-<!-- LIf this PR is related to any existing issues, mention them here (e.g., "Fixes #123"). -->
-
-## Screenshots (if applicable)
-
 <!-- Add any relevant screenshots or images, including before and after if possible. -->
 
-## Additional notes
-
-<!-- Any additional context or information. -->
+<!-- If this PR is related to any existing issues, mention them here (e.g., "Fixes #123"). -->
 
 ## Checklist
 - [ ] I have tested these changes locally using `npm run build` and `npx run playwright`

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting Security Issues
+
+If you find a security vulnerability, please:
+
+1. Avoid sharing the issue publicly until it is fixed.
+
+2. [Report the vulnerability privately via GitHub](https://github.com/cjrace/almostyellow/security/advisories/new).
+
+3. Include a description, steps to reproduce, and affected versions.
+
+4. We'll acknowledge your report as soon as practicable.
+
+## Supported Versions
+
+Only the latest stable release is actively maintained.

--- a/.github/bug_report.md
+++ b/.github/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Report a bug or unexpected behaviour
+---
+
+## Description
+
+<!-- Briefly describe the issue you encountered. -->
+
+## Steps to Reproduce
+
+<!-- 
+* Describe the steps to reproduce the bug.
+* Include any relevant code snippets or screenshots.
+-->
+
+## Expected Behavior
+
+<!-- Describe what you expected to happen instead. -->
+
+## Additional Information
+
+<!-- Include any additional information you can, e.g.
+- Operating System
+- Browser (if applicable)
+- URL you were visiting
+-->

--- a/.github/documentation_improvement.md
+++ b/.github/documentation_improvement.md
@@ -1,0 +1,12 @@
+---
+name: Documentation improvement
+about: Suggest improvements to documentation
+---
+
+## Description
+
+<!-- Describe the area of documentation that needs improvement. -->
+
+## Suggested Changes
+
+<!-- Provide details on what changes or additions you'd like to see in the documentation. -->

--- a/.github/feature_request.md
+++ b/.github/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an enhancement or new feature
+---
+
+## Description
+
+<!-- Briefly describe the feature you'd like to see. -->
+
+## Use case
+
+<!-- 
+Explain the use case or scenario where this feature would be valuable. 
+Ideally through a user story, e.g.
+As a ...
+I want ...
+So that ...
+-->
+
+## Additional Context
+
+<!-- Any additional context or information related to the feature request. -->

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Cam Race and Laura Selby
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Playwright Tests](https://github.com/cjrace/almostyellow/actions/workflows/playwright.yml/badge.svg)](https://github.com/cjrace/almostyellow/actions/workflows/playwright.yml)
+[![Playwright tests](https://github.com/cjrace/almostyellow/actions/workflows/playwright.yml/badge.svg)](https://github.com/cjrace/almostyellow/actions/workflows/playwright.yml)
 
 # Almost yellow
 
@@ -14,7 +14,7 @@ Start by installing dependencies:
 npm install
 ```
 
-To run the development server (use Ctrl-c if running in VSCode to cancel the development server):
+To run the development server (use `Ctrl-C` if running in VSCode to cancel the development server):
 
 ```bash
 npm run dev


### PR DESCRIPTION
Add basic templates for all standard things on the community checklist for GitHub projects, including:

- PR template
- Issue templates
- Code of Conduct
- Contributing guide
- Security policy
- License