### PR TITLE
Move to clarity to it's own script

### DIFF
--- a/components/MicrosoftClarity.tsx
+++ b/components/MicrosoftClarity.tsx
@@ -1,0 +1,15 @@
+import Script from 'next/script';
+
+const MicrosoftClarity = () => {
+  const trackingCode = process.env.NEXT_PUBLIC_MICROSOFT_CLARITY;
+
+  return (
+    <Script
+      id="microsoft-clarity-init"
+      strategy="afterInteractive"
+      src={`https://www.clarity.ms/tag/${trackingCode}`}
+    />
+  );
+};
+
+export default MicrosoftClarity;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,30 +1,28 @@
-import '../app/globals.css';
-import Head from 'next/head';
-import { AppProps } from 'next/app';
-import Script from 'next/script'
-import React from 'react';
-import '@mantine/core/styles.css';
-import { MantineProvider } from '@mantine/core';
+import "../app/globals.css";
+import Head from "next/head";
+import { AppProps } from "next/app";
+import React from "react";
+import "@mantine/core/styles.css";
+import { MantineProvider } from "@mantine/core";
+import MicrosoftClarity from "../components/MicrosoftClarity";
 
 const toggleDarkMode = () => {
-  document.body.classList.toggle('dark-mode');
+  document.body.classList.toggle("dark-mode");
 };
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <Head>
+        <MicrosoftClarity />
         <title>Almost yellow</title>
       </Head>
 
-      <Script src="https://www.clarity.ms/tag/o05b82hwae" type="text/javascript"/>
-
       <MantineProvider>
-      <button onClick={toggleDarkMode}>Toggle Dark Mode</button>
+        <button onClick={toggleDarkMode}>Toggle Dark Mode</button>
 
-      <Component {...pageProps} />
+        <Component {...pageProps} />
       </MantineProvider>
-
     </>
   );
 }


### PR DESCRIPTION
## Overview of changes

Moved clarity about a bit, seems to be working locally without console errors any more, fingers cross should work when deployed?

## Checklist
- [x] I have tested these changes locally using `npm run build` and `npx run playwright`
- [x] I have updated the documentation (if needed)
- [x] I have added or updated tests for these changes (if applicable)

## Reviewer instructions

Nothing specific