### PR TITLE
Change back to top to use affix

### DIFF
--- a/components/backtotop.tsx
+++ b/components/backtotop.tsx
@@ -1,20 +1,28 @@
 import React from "react";
-import { Button } from "@mantine/core";
+import { useWindowScroll } from "@mantine/hooks";
+import { Button, Transition, rem, Affix } from "@mantine/core";
+import { IconArrowUp } from "@tabler/icons-react";
 
-interface BackToTopButtonProps {
-  className?: string;
-}
-
-const BackToTopButton: React.FC<BackToTopButtonProps> = ({ className }) => {
-  const handleBackToTop = () => {
-    window.scrollTo({ top: 0, behavior: "smooth" });
-  };
+const BackToTop: React.FC = () => {
+  const [scroll, scrollTo] = useWindowScroll();
 
   return (
-    <Button onClick={handleBackToTop} className={className}>
-      Back to Top
-    </Button>
+    <Affix position={{ bottom: 20, right: 20 }}>
+      <Transition transition="slide-up" mounted={scroll.y > 0}>
+        {(transitionStyles) => (
+          <Button
+            leftSection={
+              <IconArrowUp style={{ width: rem(16), height: rem(16) }} />
+            }
+            style={transitionStyles}
+            onClick={() => scrollTo({ y: 0 })}
+          >
+            Back to top
+          </Button>
+        )}
+      </Transition>
+    </Affix>
   );
 };
 
-export default BackToTopButton;
+export default BackToTop;

--- a/pages/cocktails.tsx
+++ b/pages/cocktails.tsx
@@ -4,8 +4,8 @@ import styles from "../app/page.module.css";
 import { SpiritSelect } from "../components/cocktails/spiritselect";
 import { cocktails } from "../components/cocktails/cocktails";
 import CocktailBox from "../components/cocktails/cocktailbox";
+import BackToTop from "../components/backtotop";
 import { Breadcrumbs, Anchor } from "@mantine/core";
-import BackToTopButton from "../components/backtotop";
 
 const crumbitems = [
   { title: "Home", href: "/" },
@@ -67,7 +67,7 @@ const CocktailsPage: React.FC = () => {
             ))}
         </ul>
 
-        <BackToTopButton className={styles.backToTopButton} />
+        <BackToTop />
       </main>
     </div>
   );

--- a/pages/holidays.tsx
+++ b/pages/holidays.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text, Timeline, Breadcrumbs, Anchor } from "@mantine/core";
 import styles from "../app/page.module.css";
-import BackToTopButton from "../components/backtotop";
+import BackToTop from "../components/backtotop";
 import {
   IconSun,
   IconShip,
@@ -256,7 +256,7 @@ const HolidaysPage: React.FC = () => {
           </Timeline.Item>
         </Timeline>
 
-        <BackToTopButton className={styles.backToTopButton} />
+        <BackToTop />
       </main>
     </div>
   );


### PR DESCRIPTION
## Overview of changes

Quick one as I stumbled on the affix component in our previous notes on trello and realised I should have used that for the back to top earlier.

It's a bit cleaner than the button demo'd in #48, as this only appears after scrolling has started.

Video demo in light mode:
https://github.com/user-attachments/assets/8686df93-8b6a-41fd-b468-53b1715f12be

Dark mode view:
![image](https://github.com/user-attachments/assets/e4042e82-1f35-4cf8-a989-90080a98e0ca)

## Checklist

- [x] I have tested these changes locally using `npm run test`
- [x] I have updated the documentation (if needed)
- [ ] I have added or updated tests for these changes (if applicable)

## Reviewer instructions

Nothing specific - this is the [mantine affix component](https://mantine.dev/core/affix/)