### PR TITLE
Add extra cocktails and switch to left radio panel

### DIFF
--- a/app/cocktails.module.css
+++ b/app/cocktails.module.css
@@ -1,0 +1,62 @@
+/* Cocktail card container */
+.cocktailBox {
+  padding: 5px;
+  margin-bottom: 10px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background-color: orange;
+}
+
+/* Styles for the cocktail name */
+.cocktailName {
+  display: flex;
+  flex-direction: column; /* Stack items vertically */
+  align-items: flex-start; /* Align items to the start (left) */
+  padding: 10px;
+  font-weight: bold;
+  font-size: 16px;
+  color: black;
+}
+
+/* Styles for the cocktail rating */
+.ratingContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+/* Cocktail image */
+.cocktailImageContainer {
+  display: flex;
+  align-items: center;
+  margin-bottom: 5px;
+  background-color: #ffff65;
+}
+
+.cocktailImage {
+  border-radius: 4px;
+}
+
+/* Cocktail details */
+.cocktailDetails {
+  display: flex; /* Flexbox layout */
+  gap: 20px; /* Spacing between columns (adjust as needed) */
+  font-family: var(--font-family);
+  font-size: 14px;
+  color: #333;
+  background-color: white;
+  padding: 20px;
+}
+
+/* Each column (ingredients and instructions) */
+.column {
+  flex: 1; /* Distribute available space equally between columns */
+}
+
+/* Ingredients list */
+.ingredientsList {
+  list-style-type: disc;
+  padding-inline-start: 20px;
+  margin-top: 10px;
+  margin-bottom: 20px;
+}

--- a/components/cocktails/cocktails.ts
+++ b/components/cocktails/cocktails.ts
@@ -233,6 +233,39 @@ export const cocktails = [
       ],
     },
   },
+  {
+    name: "Laura's cloudy surprise",
+    spirits: ["Rum"],
+    rating: 4.5 as number, // Rated out of 5
+    photoUrl: "/images/cocktail-placeholder.jpg",
+    recipe: {
+      ingredients: [
+        "1 x Dark rum",
+        "1 x Cherry rum",
+        "1 x Triple sec",
+        "Cloudy cider (some)",
+        "Sugar syrup (1 splash)",
+      ],
+      instructions: ["Pour everything into glass and shake or stir"],
+    },
+  },
+  {
+    name: "Cam's cloudy surprise",
+    spirits: ["Rum", "Whisky"],
+    rating: 4.5 as number, // Rated out of 5
+    photoUrl: "/images/cocktail-placeholder.jpg",
+    recipe: {
+      ingredients: [
+        "1 x Dark rum",
+        "1 x Cherry rum",
+        "1 x Whisky (smoky)",
+        "1 x Triple sec",
+        "Cloudy cider (some)",
+        "Sugar syrup (1 splash)",
+      ],
+      instructions: ["Pour everything into glass and shake or stir"],
+    },
+  },
 
   // Add more cocktails...
 ];

--- a/components/cocktails/cocktails.ts
+++ b/components/cocktails/cocktails.ts
@@ -155,7 +155,7 @@ export const cocktails = [
         "2 x Tequila",
         "1 x Triple sec",
         "1 x Lemon juice",
-        "4 x orange juice",
+        "4 x Orange juice",
         "Grenadine",
       ],
       instructions: [
@@ -164,6 +164,72 @@ export const cocktails = [
         "Add all other ingredients to a cocktail shaker with ice",
         "Shake loads",
         "Pour slowly into glass on top of grenadine",
+      ],
+    },
+  },
+  {
+    name: "Luigi",
+    spirits: ["Gin"],
+    rating: 4.0 as number, // Rated out of 5
+    photoUrl: "/images/cocktail-placeholder.jpg",
+    recipe: {
+      ingredients: [
+        "4 x Gin",
+        "2 x Orange Juice",
+        "2 x Vermouth (dry officially, but sweet is usually nicer)",
+        "1 x Cointreau",
+        "Grenadine",
+      ],
+      instructions: [
+        "Need to redo this to retest the method",
+        "Add all ingredients to a cocktail shaker with ice",
+        "Shake loads",
+        "Pour into glass",
+        "Optional - pour a dash of grenadine on top once in the glass",
+        "Optional - orange twist to garnish",
+      ],
+    },
+  },
+  {
+    name: "Honolulu",
+    spirits: ["Gin"],
+    rating: 4.0 as number, // Rated out of 5
+    photoUrl: "/images/cocktail-placeholder.jpg",
+    recipe: {
+      ingredients: [
+        "3 x Gin",
+        "1 x Pineapple juice",
+        "1 x Orange juice",
+        "1 x Lemon juice",
+        "Grenadine",
+      ],
+      instructions: [
+        "Need to redo this to retest the method",
+        "Add all ingredients to a cocktail shaker with ice",
+        "Shake loads",
+        "Pour into glass",
+        "Optional - pour a dash of grenadine on top once in the glass",
+        "Optional - cherries on top",
+      ],
+    },
+  },
+  {
+    name: "Manhattan",
+    spirits: ["Whisky"],
+    rating: 3.0 as number, // Rated out of 5
+    photoUrl: "/images/cocktail-placeholder.jpg",
+    recipe: {
+      ingredients: [
+        "2 x Whisky (Rye)",
+        "1 x Vermouth (sweet)",
+        "Angostura bitters (2 dashes)",
+        "Orange bitters (1 dash)",
+      ],
+      instructions: [
+        "Need to redo this to retest the method",
+        "Add all ingredients to a cocktail shaker with ice",
+        "Shake loads",
+        "Pour into glass",
       ],
     },
   },

--- a/components/cocktails/spiritselect.tsx
+++ b/components/cocktails/spiritselect.tsx
@@ -11,6 +11,7 @@ export const spiritOptions = [
   { value: "Rum", label: "Rum" },
   { value: "Tequila", label: "Tequila" },
   { value: "Vodka", label: "Vodka" },
+  { value: "Whisky", label: "Whisky" },
 
   // Add other spirit options
 ];

--- a/components/cocktails/spiritselect.tsx
+++ b/components/cocktails/spiritselect.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import Select from "react-select";
-import { Controller, Control, FieldValues } from "react-hook-form";
+import { Control, Controller, FieldValues } from "react-hook-form";
+import { RadioGroup, Radio } from "@mantine/core";
 
 // List the dropdown options
 export const spiritOptions = [
@@ -16,7 +16,6 @@ export const spiritOptions = [
   // Add other spirit options
 ];
 
-// Create and export the dropdown selection code
 interface SpiritSelectProps {
   control: Control<FieldValues>;
   setSelectedSpirits: React.Dispatch<
@@ -30,19 +29,35 @@ export const SpiritSelect: React.FC<SpiritSelectProps> = ({
 }) => {
   return (
     <Controller
-      name="selectedSpirits"
+      name="selectedSpirit"
       control={control}
       render={({ field }) => (
-        <Select
-          {...field}
-          options={spiritOptions}
-          onChange={(selectedOption) => {
-            setSelectedSpirits(selectedOption ? [selectedOption] : []);
+        <RadioGroup
+          label="Filter by spirit"
+          variant="vertical"
+          size="lg"
+          value={field.value}
+          onChange={(value) => {
+            field.onChange(value);
+            setSelectedSpirits([
+              {
+                value,
+                label:
+                  spiritOptions.find((option) => option.value === value)
+                    ?.label || "",
+              },
+            ]);
           }}
-        />
+        >
+          {spiritOptions.map((option) => (
+            <Radio
+              key={option.value}
+              value={option.value}
+              label={option.label}
+            />
+          ))}
+        </RadioGroup>
       )}
     />
   );
 };
-
-export default SpiritSelect;

--- a/pages/cocktails.tsx
+++ b/pages/cocktails.tsx
@@ -46,7 +46,6 @@ const CocktailsPage: React.FC = () => {
 
       {/* The dropdown selector */}
       <form onSubmit={handleSubmit(handleFormSubmit)}>
-        <p>Filter by spirit:</p>
         <SpiritSelect
           control={control}
           setSelectedSpirits={setSelectedSpirits}

--- a/pages/cocktails.tsx
+++ b/pages/cocktails.tsx
@@ -39,36 +39,32 @@ const CocktailsPage: React.FC = () => {
     );
   });
 
-  // Main page
   return (
     <div className={styles.page}>
-      <main className={styles.main}>
-        <Breadcrumbs>{crumbitems}</Breadcrumbs>
+      <Breadcrumbs>{crumbitems}</Breadcrumbs>
+      <h1>Cocktails</h1>
 
-        <h1>Cocktails</h1>
+      {/* The dropdown selector */}
+      <form onSubmit={handleSubmit(handleFormSubmit)}>
+        <p>Filter by spirit:</p>
+        <SpiritSelect
+          control={control}
+          setSelectedSpirits={setSelectedSpirits}
+        />
+      </form>
 
-        {/* The dropdown selector */}
-        <form onSubmit={handleSubmit(handleFormSubmit)}>
-          <p>Filter by spirit:</p>
-          <SpiritSelect
-            control={control}
-            setSelectedSpirits={setSelectedSpirits}
-          />
-        </form>
+      {/* List of cocktails */}
+      <ul className={styles.cocktailList}>
+        {filteredCocktails
+          .sort((a, b) => a.name.localeCompare(b.name)) // Sort alphabetically
+          .map((cocktail) => (
+            <div key={cocktail.name} className={styles.cocktailCard}>
+              <CocktailBox {...cocktail} />
+            </div>
+          ))}
+      </ul>
 
-        {/* List of cocktails */}
-        <ul className={styles.cocktailList}>
-          {filteredCocktails
-            .sort((a, b) => a.name.localeCompare(b.name)) // Sort alphabetically
-            .map((cocktail) => (
-              <div key={cocktail.name} className={styles.cocktailCard}>
-                <CocktailBox {...cocktail} />
-              </div>
-            ))}
-        </ul>
-
-        <BackToTop />
-      </main>
+      <BackToTop />
     </div>
   );
 };


### PR DESCRIPTION
## Overview of changes

Added extra cocktails to the list, think that's all the ones we've tried and have on trello as good recipes now. Marked them as green as I went.

Changed the select dropdown to be a radio list on the left and played with the width a bit so the cocktail box sizes didn't jump around as much (probably better ways to do this).

Not 100% sold on the left panel instead of the dropdown, but it's here now.

Previous dropdonw:
![image](https://github.com/user-attachments/assets/473724dd-a770-48ce-9a86-2ce1cf54b9cb)

New left hand radio filter:
![image](https://github.com/user-attachments/assets/cc464354-4000-48d5-afc4-65c74232b8f0)

It also sticks to the top of the page as you scroll:
![image](https://github.com/user-attachments/assets/dca774bb-1f8b-421d-a114-def0b5c83fc1)

## Checklist

- [x] I have tested these changes locally using `npm run test`
- [x] I have updated the documentation (if needed)
- [ ] I have added or updated tests for these changes (if applicable)

## Reviewer instructions

Nothing specific.