### PR TITLE
Mobile tidy up

### DIFF
--- a/src/app/(homepage)/page.tsx
+++ b/src/app/(homepage)/page.tsx
@@ -1,4 +1,4 @@
-import { Button, Group, Title, Text, Space, Stack } from "@mantine/core";
+import { Button, Group, Title, Space } from "@mantine/core";
 import {
   IconDeviceGamepad2,
   IconMoodPuzzled,

--- a/src/app/(homepage)/page.tsx
+++ b/src/app/(homepage)/page.tsx
@@ -62,16 +62,6 @@ export default function Home() {
           >
             Cocktail time!
           </Button>
-
-          <Button
-            leftSection={<IconBeach />}
-            variant="default"
-            component="a"
-            size="xl"
-            href="/holidays"
-          >
-            Our holidays!
-          </Button>
         </Group>
 
         <Space h="lg" />

--- a/src/app/(homepage)/page.tsx
+++ b/src/app/(homepage)/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
 
       <main>
         <Title className={styles.gradient} ta="center">
-          Almost yellow
+          Almost Yellow
         </Title>
 
         <Space h="xl" />

--- a/src/app/admin/(admin)/page.tsx
+++ b/src/app/admin/(admin)/page.tsx
@@ -1,7 +1,8 @@
-import { Anchor, Button, Title } from "@mantine/core";
+import { Button, Title, Group, Space } from "@mantine/core";
 import { Metadata } from "next";
 import Header from "@/components/header";
 import { signOut } from "@/auth";
+import { IconShoppingCart, IconBeach } from "@tabler/icons-react";
 
 export const metadata: Metadata = {
   title: "Admin",
@@ -18,28 +19,44 @@ export default function Admin() {
       <Header crumbs={crumbitems} />
 
       <main>
-        <Title>Welcome to our admin page</Title>
+        <Title ta="center">Admin</Title>
 
-        <ul>
-          <li>
-            <Anchor href="/admin/chopinliszt">Chopin Liszt</Anchor>
-          </li>
-          <li>
-            <Anchor href="/admin">???</Anchor>
-          </li>
-          <li>
-            <Anchor href="/admin">???</Anchor>
-          </li>
-        </ul>
+        <Space h="xl" />
 
-        <Button
-          onClick={async () => {
-            "use server";
-            await signOut();
-          }}
-        >
-          Sign out
-        </Button>
+        <Group justify="center" gap="xl">
+          <Button
+            leftSection={<IconShoppingCart />}
+            variant="default"
+            component="a"
+            size="xl"
+            href="/admin/chopinliszt"
+          >
+            Chopin Liszt
+          </Button>
+
+          <Button
+            leftSection={<IconBeach />}
+            variant="default"
+            component="a"
+            size="xl"
+            href="/admin/holidays"
+          >
+            Our holidays!
+          </Button>
+        </Group>
+
+        <Space h="lg" />
+
+        <Group justify="center">
+          <Button
+            onClick={async () => {
+              "use server";
+              await signOut();
+            }}
+          >
+            Sign out
+          </Button>
+        </Group>
       </main>
     </>
   );

--- a/src/app/admin/holidays/page.tsx
+++ b/src/app/admin/holidays/page.tsx
@@ -6,15 +6,11 @@ import { Title } from "@mantine/core";
 
 export const metadata: Metadata = {
   title: "Holidays",
-  description: "A timeline of our adventures.",
-  openGraph: {
-    title: "Holidays | Almost Yellow",
-    description: "A timeline of our adventures.",
-  },
 };
 
 const crumbitems = [
   { title: "Home", href: "/" },
+  { title: "Admin", href: "/admin/" },
   { title: "Holidays", href: "" },
 ];
 

--- a/src/app/admin/holidays/page.tsx
+++ b/src/app/admin/holidays/page.tsx
@@ -2,7 +2,7 @@ import BackToTop from "@/components/backtotop";
 import HolidayTimeline from "@/components/timeline";
 import { Metadata } from "next";
 import Header from "@/components/header";
-import { Title } from "@mantine/core";
+import { Container, Title } from "@mantine/core";
 
 export const metadata: Metadata = {
   title: "Holidays",
@@ -20,9 +20,11 @@ export default function HolidaysPage() {
       <Header crumbs={crumbitems} />
 
       <main>
-        <Title>Our trips and holidays</Title>
-        <HolidayTimeline />
-        <BackToTop />
+        <Container size="xs">
+          <Title>Our trips and holidays</Title>
+          <HolidayTimeline />
+          <BackToTop />
+        </Container>
       </main>
     </>
   );

--- a/src/app/cocktails/page.tsx
+++ b/src/app/cocktails/page.tsx
@@ -2,7 +2,7 @@ import Cocktails from "@/components/cocktails";
 import BackToTop from "@/components/backtotop";
 import { Metadata } from "next";
 import Header from "@/components/header";
-import { Title } from "@mantine/core";
+import { Container, Title } from "@mantine/core";
 
 export const metadata: Metadata = {
   title: "Cocktails",
@@ -24,9 +24,11 @@ export default function CocktailsPage() {
       <Header crumbs={crumbitems} />
 
       <main>
-        <Title>Cocktails</Title>
-        <Cocktails />
-        <BackToTop />
+        <Container size="lg">
+          <Title>Cocktails</Title>
+          <Cocktails />
+          <BackToTop />
+        </Container>
       </main>
     </>
   );

--- a/src/app/games/boomboompirate/page.tsx
+++ b/src/app/games/boomboompirate/page.tsx
@@ -12,16 +12,10 @@ export const metadata: Metadata = {
   },
 };
 
-const crumbitems = [
-  { title: "Home", href: "/" },
-  { title: "Games", href: "/games" },
-  { title: "Boom Boom Pirate", href: "" },
-];
-
 export default function BoomBoomPiratePage() {
   return (
     <>
-      <Header crumbs={crumbitems} />
+      <Header noCrumbs={true} game={true} />
 
       <main>
         <Title>Boom Boom Pirate</Title>

--- a/src/app/games/irishbingo/page.tsx
+++ b/src/app/games/irishbingo/page.tsx
@@ -1,4 +1,3 @@
-import { Space, Title } from "@mantine/core";
 import IrishBingo from "@/components/irishbingo";
 import { Metadata } from "next";
 import Header from "@/components/header";
@@ -18,8 +17,6 @@ export default function IrishBingoPage() {
       <Header noCrumbs={true} game={true} />
 
       <main>
-        <Title>Irish Bingo</Title>
-        <Space h="xl" />
         <IrishBingo />
       </main>
     </>

--- a/src/app/games/irishbingo/page.tsx
+++ b/src/app/games/irishbingo/page.tsx
@@ -12,16 +12,10 @@ export const metadata: Metadata = {
   },
 };
 
-const crumbitems = [
-  { title: "Home", href: "/" },
-  { title: "Games", href: "/games" },
-  { title: "Irish Bingo", href: "" },
-];
-
 export default function IrishBingoPage() {
   return (
     <>
-      <Header crumbs={crumbitems} />
+      <Header noCrumbs={true} game={true} />
 
       <main>
         <Title>Irish Bingo</Title>

--- a/src/app/games/snakesandladders/page.tsx
+++ b/src/app/games/snakesandladders/page.tsx
@@ -13,16 +13,10 @@ export const metadata: Metadata = {
   },
 };
 
-const crumbitems = [
-  { title: "Home", href: "/" },
-  { title: "Games", href: "/games" },
-  { title: "Snakes and Ladders", href: "" },
-];
-
 export default function SnakesAndLaddersPage() {
   return (
     <>
-      <Header crumbs={crumbitems} />
+      <Header noCrumbs={true} game={true} />
 
       <main>
         <Title>Snakes and Ladders</Title>

--- a/src/app/games/uno/page.tsx
+++ b/src/app/games/uno/page.tsx
@@ -6,16 +6,10 @@ export const metadata: Metadata = {
   title: "Uno",
 };
 
-const crumbitems = [
-  { title: "Home", href: "/" },
-  { title: "Games", href: "/games" },
-  { title: "Uno", href: "/games/uno" },
-];
-
 export default async function UnoPage() {
   return (
     <>
-      <Header crumbs={crumbitems} />
+      <Header noCrumbs={true} game={true} />
 
       <main>
         <Title>Uno</Title>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -44,11 +44,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.9,
     },
-    {
-      url: "https://www.almostyellow.co.uk/holidays",
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.4,
-    },
   ];
 }

--- a/src/components/cocktails.tsx
+++ b/src/components/cocktails.tsx
@@ -1,96 +1,63 @@
 "use client";
 
-import { Grid, RadioGroup, Radio } from "@mantine/core";
+import { NativeSelect, Space } from "@mantine/core";
 import { useState } from "react";
 import { cocktaildata } from "@/components/cocktaildata";
 import styles from "@/styles/cocktails.module.css";
 import CocktailBox from "@/components/cocktailbox";
 
-// List the dropdown options
-const spiritOptions = [
-  { value: "All spirits", label: "All spirits" },
-  { value: "Baileys", label: "Baileys" },
-  { value: "Gin", label: "Gin" },
-  { value: "Kahlua", label: "Kahlua" },
-  { value: "Rum", label: "Rum" },
-  { value: "Tequila", label: "Tequila" },
-  { value: "Vodka", label: "Vodka" },
-  { value: "Whisky", label: "Whisky" },
-  // Add other spirit options as they get added. // TODO: auto generate from data
+interface Cocktail {
+  name: string;
+  spirits: string[];
+  rating: number;
+  photoUrl: string;
+  recipe: {
+    ingredients: string[];
+    instructions: string[];
+  };
+}
+
+// Generate the dropdown options
+const uniqueSpirits = [
+  "All spirits",
+  ...new Set(cocktaildata.flatMap((cocktail) => cocktail.spirits).sort()),
 ];
 
 export default function Cocktails() {
-  const [selectedSpirits, setSelectedSpirits] = useState<
-    { value: string; label: string }[]
-  >([]);
+  const [selectedSpirits, setSelectedSpirits] = useState<string[]>([]);
 
-  // Show all cocktails if no specific spirits are selected or if "All Spirits" is selected
-  const filteredCocktails = cocktaildata.filter((cocktail) => {
-    if (
-      selectedSpirits.length === 0 ||
-      selectedSpirits.some((spirit) => spirit.value === "All spirits")
-    ) {
-      return true;
-    }
-    return cocktail.spirits.some((spirit) =>
-      selectedSpirits.some((selectedSpirit) => selectedSpirit.value === spirit),
+  const handleChange = (value: string) => {
+    setSelectedSpirits(value === "All spirits" ? [] : [value]);
+  };
+
+  const filteredCocktails = cocktaildata.filter((cocktail: Cocktail) => {
+    return (
+      selectedSpirits.length === 0 || // Show all if no spirits selected
+      cocktail.spirits.some((spirit) => selectedSpirits.includes(spirit)) // Show if any selected spirit matches
     );
   });
 
-  const [selectedSpirit, setSelectedSpirit] = useState("All spirits");
-
-  const handleChange = (value: string) => {
-    setSelectedSpirit(value);
-
-    // If the selected spirit is "All spirits", set the selectedSpirits to an empty array
-    if (value === "All spirits") {
-      setSelectedSpirits([]);
-      return;
-    }
-
-    // Otherwise, update the selectedSpirits array
-    setSelectedSpirits([
-      {
-        value,
-        label:
-          spiritOptions.find((option) => option.value === value)?.label || "",
-      },
-    ]);
-  };
-
   return (
-    <Grid>
-      <Grid.Col span={{ base: 12, sm: 2 }}>
-        <div style={{ position: "sticky", top: "10px" }}>
-          <RadioGroup
-            label="Filter by spirit"
-            variant="vertical"
-            size="lg"
-            value={selectedSpirit}
-            onChange={handleChange}
-          >
-            {spiritOptions.map((option) => (
-              <Radio
-                key={option.value}
-                value={option.value}
-                label={option.label}
-              />
-            ))}
-          </RadioGroup>
-        </div>
-      </Grid.Col>
-
-      <Grid.Col span={{ base: 12, sm: 9 }}>
-        <div className={styles.cocktailList}>
-          {filteredCocktails
-            .sort((a, b) => a.name.localeCompare(b.name)) // Sort alphabetically
-            .map((cocktail) => (
-              <div key={cocktail.name} className={styles.cocktailCard}>
-                <CocktailBox {...cocktail} />
-              </div>
-            ))}
-        </div>
-      </Grid.Col>
-    </Grid>
+    <>
+      <Space h="md" />
+      <NativeSelect
+        aria-label="Filter by base spirit"
+        value={
+          selectedSpirits.length === 0 ? "All spirits" : selectedSpirits[0]
+        }
+        onChange={(event) => handleChange(event.target.value)}
+        data={uniqueSpirits}
+      />
+      <Space h="md" />
+      <div className={styles.cocktailList}>
+        {filteredCocktails
+          .sort((a, b) => a.name.localeCompare(b.name)) // Sort alphabetically
+          .map((cocktail) => (
+            <div key={cocktail.name} className={styles.cocktailCard}>
+              <CocktailBox {...cocktail} />
+            </div>
+          ))}
+      </div>
+    </>
   );
 }

--- a/src/components/decisionmaker.tsx
+++ b/src/components/decisionmaker.tsx
@@ -27,15 +27,23 @@ export default function DecisionMaker() {
     },
   });
 
+  const [isLoading, setIsLoading] = useState(false);
+
   const makeDecision = (data: DecisionOptions) => {
-    const options = data.options
-      .split("\n")
-      .filter((option) => option.trim() !== "");
-    if (options.length > 0) {
-      const randomIndex = Math.floor(Math.random() * options.length);
-      setChosenItem(options[randomIndex]);
-      playConfetti();
-    }
+    setIsLoading(true);
+
+    setTimeout(() => {
+      const options = data.options
+        .split("\n")
+        .filter((option) => option.trim() !== "");
+      if (options.length > 0) {
+        const randomIndex = Math.floor(Math.random() * options.length);
+        setChosenItem(options[randomIndex]);
+        playConfetti();
+      }
+
+      setIsLoading(false);
+    }, 3000);
   };
 
   return (
@@ -50,8 +58,8 @@ export default function DecisionMaker() {
           minRows={2}
           {...form.getInputProps("options")}
         />
-        <Button mt="xl" type="submit" fullWidth>
-          Make a decision
+        <Button mt="xl" type="submit" fullWidth disabled={isLoading}>
+          {isLoading ? "Pondering choices..." : "Make a decision"}
         </Button>
       </Form>
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -9,7 +9,12 @@ import {
   useComputedColorScheme,
   Tooltip,
 } from "@mantine/core";
-import { IconBrandGithub, IconConfetti } from "@tabler/icons-react";
+import {
+  IconBrandGithub,
+  IconConfetti,
+  IconDeviceGamepad2,
+  IconChevronLeft,
+} from "@tabler/icons-react";
 import playConfetti from "@/components/playconfetti";
 import { IconMoon, IconSun } from "@tabler/icons-react";
 import cx from "clsx";
@@ -23,10 +28,15 @@ interface BreadcrumbItem {
 interface HeaderProps {
   crumbs?: BreadcrumbItem[];
   noCrumbs?: boolean; // Put this in so we can avoid showing crumbs on home and login pages
+  game?: boolean; // Here to give a specific header styling for our games pages
 }
 
-export default function Header({ crumbs, noCrumbs = false }: HeaderProps) {
-  const mainJustify = noCrumbs ? "flex-end" : "space-between"; // This keeps the icon buttons on the right when there's no crumbs
+export default function Header({
+  crumbs,
+  noCrumbs = false,
+  game = false,
+}: HeaderProps) {
+  const mainJustify = noCrumbs && !game ? "flex-end" : "space-between"; // This keeps the icon buttons on the right when there's no crumbs
   const { setColorScheme } = useMantineColorScheme();
   const computedColorScheme = useComputedColorScheme("dark", {
     getInitialValueInEffect: true,
@@ -45,6 +55,22 @@ export default function Header({ crumbs, noCrumbs = false }: HeaderProps) {
               ))}
             </Breadcrumbs>
           </Group>
+        )}
+
+        {game && (
+          <Tooltip label="Back to our games list" openDelay={250}>
+            <ActionIcon
+              variant="default"
+              component="a"
+              href="/games"
+              size="xl"
+              aria-label="Back to our games list"
+              style={{ width: 70 }}
+            >
+              <IconChevronLeft />
+              <IconDeviceGamepad2 />
+            </ActionIcon>
+          </Tooltip>
         )}
 
         <Group h="100%" gap="xs" justify="flex-end">

--- a/src/components/irishbingo.tsx
+++ b/src/components/irishbingo.tsx
@@ -10,15 +10,19 @@ import {
   Image,
   Box,
   Progress,
-  Accordion,
+  Group,
+  ActionIcon,
   Text,
   Title,
   List,
   Modal,
+  Anchor,
+  Tooltip,
+  Center,
+  Container,
 } from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
 import playConfetti from "@/components/playconfetti";
-import { IconConfetti } from "@tabler/icons-react";
+import { IconConfetti, IconInfoCircle } from "@tabler/icons-react";
 
 const CalloutBox: React.FC<{ card: Card | null }> = ({ card }) => (
   <Box
@@ -91,10 +95,123 @@ export default function IrishBingo() {
     setLatestCard(null); // Clear the latest card
   };
 
-  const [opened, { open, close }] = useDisclosure(false);
+  const [modalCardOpened, setModalCardOpened] = useState(false);
+  const [modalInstructionsOpened, setModalIntstructionsOpened] =
+    useState(false);
 
   return (
     <Grid>
+      <Grid.Col span={12}>
+        <Group gap="xs">
+          <Title>Irish Bingo</Title>
+          <Tooltip
+            label="Game instructions"
+            openDelay={250}
+            position="right"
+            offset={5}
+          >
+            <ActionIcon
+              variant="subtle"
+              size="lg"
+              aria-label="Open game instructions modal"
+              onClick={() => setModalIntstructionsOpened(true)}
+            >
+              <IconInfoCircle />
+            </ActionIcon>
+          </Tooltip>
+        </Group>
+
+        <Modal
+          size="auto"
+          opened={modalInstructionsOpened}
+          onClose={() => setModalIntstructionsOpened(false)}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="ib_instructions"
+          withCloseButton={false}
+          transitionProps={{
+            transition: "fade",
+            duration: 300,
+            timingFunction: "linear",
+          }}
+          overlayProps={{
+            backgroundOpacity: 0.75,
+            blur: 3,
+          }}
+        >
+          <Container>
+            <Title order={2} mb="sm" id="ib_instructions">
+              Irish Bingo instructions
+            </Title>
+            <Text>This game can be played with any number of players.</Text>
+            <Title order={3} my="md">
+              Standard rules
+            </Title>
+            <List variant="ordered" mb="md">
+              <List.Item>
+                deal 13 cards at random to all players from a standard 52 card
+                deck (use multiple decks if necessary based on the number of
+                players)
+              </List.Item>
+              <List.Item>players then lay out all cards face up</List.Item>
+              <List.Item>
+                the caller then starts calling cards, players turn their cards
+                face down if they are called
+              </List.Item>
+              <List.Item>
+                first player to turn over all of their cards shouts
+                &apos;Tayto&apos; and wins
+              </List.Item>
+            </List>
+            <Text mb="sm">
+              Note that it is usually worth double checking the winners cards,
+              especially if alcohol has been involved.
+            </Text>
+            <Text mb="sm">
+              Different players can have have duplicates of cards, though no
+              individual player should have duplicate cards themselves.
+            </Text>
+            <Text>
+              For example players A and B both having the 7 of Hearts is fine,
+              but player A should not have two 7 of Hearts cards.
+            </Text>
+            <Title order={3} my="md">
+              Tie breaks
+            </Title>
+            <Text>
+              Tie breaks are decided in any way you like. We suggest a quick
+              game of{" "}
+              <Anchor
+                target="_blank"
+                href="/games/boomboompirate"
+                rel="noreferrer"
+              >
+                Boom Boom Pirate (opens in new tab)
+              </Anchor>
+              , or a simple high card draw.
+            </Text>
+            <Title order={3} my="md">
+              Variations
+            </Title>
+            <Text>
+              You can change the number of cards per player if you want a longer
+              or shorter game, or are limited in the number of cards you have.
+            </Text>
+            <Center>
+              <Button
+                variant="subtle"
+                mt="md"
+                onClick={() => setModalIntstructionsOpened(false)}
+              >
+                Close instructions modal
+              </Button>
+            </Center>
+          </Container>
+        </Modal>
+      </Grid.Col>
+
+      <Space h="xl" />
+
       <Grid.Col
         span={{ base: 4, sm: 6, lg: 6 }}
         style={{ display: "flex", justifyContent: "center" }}
@@ -120,20 +237,16 @@ export default function IrishBingo() {
           value={drawnCards.length * 1.923}
           size="lg"
           color={progressColor}
+          aria-label="Progress bar showing number of cards drawn from a standard deck of 52"
         />
-        <Text mt="sm" id="card_count">{`${drawnCards.length} / 52 cards`}</Text>
+        <Text
+          mt="sm"
+          id="card_count"
+          ta="center"
+        >{`${drawnCards.length} / 52 cards`}</Text>
         <Space h="md" />
         <Button disabled={mainDeck.length === 0} onClick={drawCard} fullWidth>
           Draw a card
-        </Button>
-        <Space h="md" />
-        <Button
-          variant="default"
-          onClick={open}
-          fullWidth
-          disabled={drawnCards.length > 1 ? false : true}
-        >
-          View all called cards
         </Button>
         <Space h="md" />
         {mainDeck.length === 0 && (
@@ -144,6 +257,38 @@ export default function IrishBingo() {
             <Space h="md" />
           </>
         )}
+        <Button
+          variant="default"
+          onClick={() => setModalCardOpened(true)}
+          fullWidth
+          disabled={drawnCards.length > 1 ? false : true}
+        >
+          View all called cards
+        </Button>
+
+        <Modal
+          opened={modalCardOpened}
+          onClose={() => setModalCardOpened(false)}
+          size="xs"
+          title="All called cards"
+          transitionProps={{
+            transition: "fade",
+            duration: 300,
+            timingFunction: "linear",
+          }}
+          closeButtonProps={{ "aria-label": "Close modal" }}
+        >
+          <List type="ordered" withPadding>
+            {drawnCards.map((card, index) => (
+              <List.Item key={index}>
+                {getCardName(card.suit, card.rank)}
+              </List.Item>
+            ))}
+          </List>
+        </Modal>
+
+        <Space h="md" />
+
         <Button
           variant="default"
           onClick={newDeck}
@@ -163,21 +308,6 @@ export default function IrishBingo() {
             Has someone won?
           </Button>
         )}
-
-        <Modal
-          opened={opened}
-          onClose={close}
-          size="xs"
-          title="All called cards"
-        >
-          <List type="ordered" withPadding>
-            {drawnCards.map((card, index) => (
-              <List.Item key={index}>
-                {getCardName(card.suit, card.rank)}
-              </List.Item>
-            ))}
-          </List>
-        </Modal>
       </Grid.Col>
     </Grid>
   );

--- a/src/components/irishbingo.tsx
+++ b/src/components/irishbingo.tsx
@@ -14,7 +14,9 @@ import {
   Text,
   Title,
   List,
+  Modal,
 } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
 import playConfetti from "@/components/playconfetti";
 import { IconConfetti } from "@tabler/icons-react";
 
@@ -27,7 +29,7 @@ const CalloutBox: React.FC<{ card: Card | null }> = ({ card }) => (
       textAlign: "center",
       position: "relative",
       width: "100%",
-      background: "#4b4b4b",
+      background: "none",
     }}
   >
     <div
@@ -89,8 +91,10 @@ export default function IrishBingo() {
     setLatestCard(null); // Clear the latest card
   };
 
+  const [opened, { open, close }] = useDisclosure(false);
+
   return (
-    <Grid gutter={{ base: 5, xs: "md", md: "xl", xl: 50 }}>
+    <Grid>
       <Grid.Col
         span={{ base: 4, sm: 6, lg: 6 }}
         style={{ display: "flex", justifyContent: "center" }}
@@ -120,44 +124,60 @@ export default function IrishBingo() {
         <Text mt="sm" id="card_count">{`${drawnCards.length} / 52 cards`}</Text>
         <Space h="md" />
         <Button disabled={mainDeck.length === 0} onClick={drawCard} fullWidth>
-          Draw a Card
+          Draw a card
         </Button>
         <Space h="md" />
-        <Button variant="default" onClick={newDeck} fullWidth>
-          Shuffle New Deck
+        <Button
+          variant="default"
+          onClick={open}
+          fullWidth
+          disabled={drawnCards.length > 1 ? false : true}
+        >
+          View all called cards
         </Button>
         <Space h="md" />
         {mainDeck.length === 0 && (
-          <Alert title="Deck Exhausted" color="red">
-            You have drawn a full deck, please reshuffle.
-          </Alert>
+          <>
+            <Alert title="Deck Exhausted" color="red">
+              You have drawn a full deck, please reshuffle.
+            </Alert>
+            <Space h="md" />
+          </>
         )}
-        <Space h="md" />
-
         <Button
           variant="default"
-          onClick={playConfetti}
+          onClick={newDeck}
           fullWidth
-          rightSection={<IconConfetti />}
+          disabled={drawnCards.length > 0 ? false : true}
         >
-          Has someone won?
+          Shuffle new deck
         </Button>
-
         <Space h="md" />
-        <Accordion variant="separated">
-          <Accordion.Item key="All cards called" value="All cards called">
-            <Accordion.Control>All cards called</Accordion.Control>
-            <Accordion.Panel>
-              <List type="ordered" withPadding>
-                {drawnCards.map((card, index) => (
-                  <List.Item key={index}>
-                    {getCardName(card.suit, card.rank)}
-                  </List.Item>
-                ))}
-              </List>
-            </Accordion.Panel>
-          </Accordion.Item>
-        </Accordion>
+        {drawnCards.length >= 10 && (
+          <Button
+            variant="default"
+            onClick={playConfetti}
+            fullWidth
+            rightSection={<IconConfetti />}
+          >
+            Has someone won?
+          </Button>
+        )}
+
+        <Modal
+          opened={opened}
+          onClose={close}
+          size="xs"
+          title="All called cards"
+        >
+          <List type="ordered" withPadding>
+            {drawnCards.map((card, index) => (
+              <List.Item key={index}>
+                {getCardName(card.suit, card.rank)}
+              </List.Item>
+            ))}
+          </List>
+        </Modal>
       </Grid.Col>
     </Grid>
   );

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -1,6 +1,6 @@
 "use client"; // TODO: Not sure this should be needed.
 
-import { Title, Text, Timeline, List, Grid } from "@mantine/core";
+import { Title, Text, Timeline, List, Grid, Container } from "@mantine/core";
 import {
   IconSun,
   IconShip,
@@ -14,244 +14,224 @@ import {
 export default function HolidayTimeline() {
   return (
     <>
-      <Grid grow justify="center">
-        <Grid.Col span={{ base: 12, md: 6, lg: 4 }}>
-          <Title order={2} my="md">
-            2022
-          </Title>
+      <Title order={2} my="md">
+        2024
+      </Title>
 
-          <Timeline color="yellow" active={1} bulletSize={24} lineWidth={2}>
-            <Timeline.Item
-              title="Adramatic loop"
-              bullet={<IconCar size="1rem" />}
-            >
-              <Text c="dimmed" size="sm">
-                We did a LOOP of
-              </Text>
-              <List>
-                <List.Item>Germany</List.Item>
-                <List.Item>Czech Republic</List.Item>
-                <List.Item>Austria</List.Item>
-                <List.Item>Slovenia</List.Item>
-                <List.Item>Italy</List.Item>
-                <List.Item>San Marino</List.Item>
-                <List.Item>Croatia</List.Item>
-                <List.Item>Bosnia and Herzegovina</List.Item>
-                <List.Item>Hungary</List.Item>
-                <List.Item>Slovakia</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                25 June - 7 July 2022
-              </Text>
-            </Timeline.Item>
+      <Timeline color="yellow" active={5} bulletSize={24} lineWidth={2}>
+        <Timeline.Item
+          title="Christmas Schtarshh"
+          bullet={<IconGift size="1rem" />}
+        >
+          <Text c="dimmed" size="sm">
+            No stars but kitchen roll kebabs
+          </Text>
+          <List>
+            <List.Item>Wild Northumberland glamping, Hexham</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            26th January - 27th January 2024
+          </Text>
+        </Timeline.Item>
 
-            <Timeline.Item
-              title="Manchester"
-              bullet={<IconBriefcase size="1rem" />}
-            >
-              <Text c="dimmed" size="sm">
-                Christmas market and deciding to live together!
-              </Text>
-              <List>
-                <List.Item>Manchester</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                12th December - 14th December 2022
-              </Text>
-            </Timeline.Item>
-          </Timeline>
-        </Grid.Col>
+        <Timeline.Item
+          title="Neath - Bristol - Bath"
+          bullet={<IconBriefcase size="1rem" />}
+        >
+          <Text c="dimmed" size="sm">
+            Strange Neath hotel, tasty cider and a speedy bath
+          </Text>
+          <List>
+            <List.Item>Neath</List.Item>
+            <List.Item>Bristol</List.Item>
+            <List.Item>Bath</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            15th March - 16th March 2024
+          </Text>
+        </Timeline.Item>
 
-        <Grid.Col span={{ base: 12, md: 6, lg: 4 }}>
-          <Title order={2} my="md">
-            2023
-          </Title>
+        <Timeline.Item title="Bulgaria" bullet={<IconSun size="1rem" />}>
+          <Text c="dimmed" size="sm">
+            Being fancy with the old leathery people
+          </Text>
+          <List>
+            <List.Item>Sunny beach, Bulgaria</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            9th June - 16th June 2024
+          </Text>
+        </Timeline.Item>
 
-          <Timeline color="yellow" active={4} bulletSize={24} lineWidth={2}>
-            <Timeline.Item
-              title="Sparkly sky"
-              bullet={<IconSnowflake size="1rem" />}
-            >
-              <Text c="dimmed" size="sm">
-                Man chop wood in the arctic circle
-              </Text>
-              <List>
-                <List.Item>Lofoten, Norway</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                3rd January - 8th January 2023
-              </Text>
-            </Timeline.Item>
+        <Timeline.Item
+          title="Laura's birthday"
+          bullet={<IconGift size="1rem" />}
+        >
+          <Text c="dimmed" size="sm">
+            Golf x2, fancy Green Egg cabin, meerkats and getting engaged!
+          </Text>
+          <List>
+            <List.Item>Lebberston</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            7th July - 9th July 2024
+          </Text>
+        </Timeline.Item>
 
-            <Timeline.Item
-              title="North coast 500"
-              bullet={<IconCar size="1rem" />}
-            >
-              <Text c="dimmed" size="sm">
-                A Scottish loop this time
-              </Text>
-              <List>
-                <List.Item>Scotland</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                1st May - 8th May 2023
-              </Text>
-            </Timeline.Item>
+        <Timeline.Item title="Cam's birthday" bullet={<IconGift size="1rem" />}>
+          <Text c="dimmed" size="sm">
+            Bottomless brunch, batting cage and escape room
+          </Text>
+          <List>
+            <List.Item>York</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            9th August - 11th August 2024
+          </Text>
+        </Timeline.Item>
 
-            <Timeline.Item
-              title="Laura's birthday"
-              bullet={<IconGift size="1rem" />}
-            >
-              <Text c="dimmed" size="sm">
-                Bell tent storm, fire pit pizza oven and Yorkshire Wildlife Park
-              </Text>
-              <List>
-                <List.Item>Catgill farm, Skipton</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                9th July - 10th July 2023
-              </Text>
-            </Timeline.Item>
+        <Timeline.Item
+          title="Surprise! Holy Island"
+          bullet={<IconMoodSurprised size="1rem" />}
+        >
+          <Text c="dimmed" size="sm">
+            Clinking our G&Ts through the graveyard
+          </Text>
+          <List>
+            <List.Item>Lindisfarne (Holy Island)</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            27th September - 29th September 2024
+          </Text>
+        </Timeline.Item>
 
-            <Timeline.Item
-              title="Cam's birthday"
-              bullet={<IconGift size="1rem" />}
-            >
-              <Text c="dimmed" size="sm">
-                Being impeccable piggies
-              </Text>
-              <List>
-                <List.Item>The impeccable pig, Sedgefield</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                7th August - 8th August 2023
-              </Text>
-            </Timeline.Item>
+        <Timeline.Item title="CROOOOSMAS" bullet={<IconShip size="1rem" />}>
+          <Text c="dimmed" size="sm">
+            Cruisin&apos; the Christmas markets in
+          </Text>
+          <List>
+            <List.Item>Zeebrugge, Belgium</List.Item>
+            <List.Item>Amsterdam, Netherlands</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            14 December - 19 December 2024
+          </Text>
+        </Timeline.Item>
+      </Timeline>
 
-            <Timeline.Item title="Gr-EES" bullet={<IconSun size="1rem" />}>
-              <Text c="dimmed" size="sm">
-                Our first all inclusive
-              </Text>
-              <List>
-                <List.Item>Kos, Greece</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                6th September - 10th September 2023
-              </Text>
-            </Timeline.Item>
-          </Timeline>
-        </Grid.Col>
+      <Title order={2} my="md">
+        2023
+      </Title>
 
-        <Grid.Col span={{ base: 12, md: 6, lg: 4 }}>
-          <Title order={2} my="md">
-            2024
-          </Title>
+      <Timeline color="yellow" active={4} bulletSize={24} lineWidth={2}>
+        <Timeline.Item
+          title="Sparkly sky"
+          bullet={<IconSnowflake size="1rem" />}
+        >
+          <Text c="dimmed" size="sm">
+            Man chop wood in the arctic circle
+          </Text>
+          <List>
+            <List.Item>Lofoten, Norway</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            3rd January - 8th January 2023
+          </Text>
+        </Timeline.Item>
 
-          <Timeline color="yellow" active={5} bulletSize={24} lineWidth={2}>
-            <Timeline.Item
-              title="Christmas Schtarshh"
-              bullet={<IconGift size="1rem" />}
-            >
-              <Text c="dimmed" size="sm">
-                No stars but kitchen roll kebabs
-              </Text>
-              <List>
-                <List.Item>Wild Northumberland glamping, Hexham</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                26th January - 27th January 2024
-              </Text>
-            </Timeline.Item>
+        <Timeline.Item title="North coast 500" bullet={<IconCar size="1rem" />}>
+          <Text c="dimmed" size="sm">
+            A Scottish loop this time
+          </Text>
+          <List>
+            <List.Item>Scotland</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            1st May - 8th May 2023
+          </Text>
+        </Timeline.Item>
 
-            <Timeline.Item
-              title="Neath - Bristol - Bath"
-              bullet={<IconBriefcase size="1rem" />}
-            >
-              <Text c="dimmed" size="sm">
-                Strange Neath hotel, tasty cider and a speedy bath
-              </Text>
-              <List>
-                <List.Item>Neath</List.Item>
-                <List.Item>Bristol</List.Item>
-                <List.Item>Bath</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                15th March - 16th March 2024
-              </Text>
-            </Timeline.Item>
+        <Timeline.Item
+          title="Laura's birthday"
+          bullet={<IconGift size="1rem" />}
+        >
+          <Text c="dimmed" size="sm">
+            Bell tent storm, fire pit pizza oven and Yorkshire Wildlife Park
+          </Text>
+          <List>
+            <List.Item>Catgill farm, Skipton</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            9th July - 10th July 2023
+          </Text>
+        </Timeline.Item>
 
-            <Timeline.Item title="Bulgaria" bullet={<IconSun size="1rem" />}>
-              <Text c="dimmed" size="sm">
-                Being fancy with the old leathery people
-              </Text>
-              <List>
-                <List.Item>Sunny beach, Bulgaria</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                9th June - 16th June 2024
-              </Text>
-            </Timeline.Item>
+        <Timeline.Item title="Cam's birthday" bullet={<IconGift size="1rem" />}>
+          <Text c="dimmed" size="sm">
+            Being impeccable piggies
+          </Text>
+          <List>
+            <List.Item>The impeccable pig, Sedgefield</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            7th August - 8th August 2023
+          </Text>
+        </Timeline.Item>
 
-            <Timeline.Item
-              title="Laura's birthday"
-              bullet={<IconGift size="1rem" />}
-            >
-              <Text c="dimmed" size="sm">
-                Golf x2, fancy Green Egg cabin, meerkats and getting engaged!
-              </Text>
-              <List>
-                <List.Item>Lebberston</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                7th July - 9th July 2024
-              </Text>
-            </Timeline.Item>
+        <Timeline.Item title="Gr-EES" bullet={<IconSun size="1rem" />}>
+          <Text c="dimmed" size="sm">
+            Our first all inclusive
+          </Text>
+          <List>
+            <List.Item>Kos, Greece</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            6th September - 10th September 2023
+          </Text>
+        </Timeline.Item>
+      </Timeline>
 
-            <Timeline.Item
-              title="Cam's birthday"
-              bullet={<IconGift size="1rem" />}
-            >
-              <Text c="dimmed" size="sm">
-                Bottomless brunch, batting cage and escape room
-              </Text>
-              <List>
-                <List.Item>York</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                9th August - 11th August 2024
-              </Text>
-            </Timeline.Item>
+      <Title order={2} my="md">
+        2022
+      </Title>
 
-            <Timeline.Item
-              title="Surprise! Holy Island"
-              bullet={<IconMoodSurprised size="1rem" />}
-            >
-              <Text c="dimmed" size="sm">
-                Clinking our G&Ts through the graveyard
-              </Text>
-              <List>
-                <List.Item>Lindisfarne (Holy Island)</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                27th September - 29th September 2024
-              </Text>
-            </Timeline.Item>
+      <Timeline color="yellow" active={1} bulletSize={24} lineWidth={2}>
+        <Timeline.Item title="Adramatic loop" bullet={<IconCar size="1rem" />}>
+          <Text c="dimmed" size="sm">
+            We did a LOOP of
+          </Text>
+          <List>
+            <List.Item>Germany</List.Item>
+            <List.Item>Czech Republic</List.Item>
+            <List.Item>Austria</List.Item>
+            <List.Item>Slovenia</List.Item>
+            <List.Item>Italy</List.Item>
+            <List.Item>San Marino</List.Item>
+            <List.Item>Croatia</List.Item>
+            <List.Item>Bosnia and Herzegovina</List.Item>
+            <List.Item>Hungary</List.Item>
+            <List.Item>Slovakia</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            25 June - 7 July 2022
+          </Text>
+        </Timeline.Item>
 
-            <Timeline.Item title="CROOOOSMAS" bullet={<IconShip size="1rem" />}>
-              <Text c="dimmed" size="sm">
-                Cruisin&apos; the Christmas markets in
-              </Text>
-              <List>
-                <List.Item>Zeebrugge, Belgium</List.Item>
-                <List.Item>Amsterdam, Netherlands</List.Item>
-              </List>
-              <Text size="xs" mt={4}>
-                14 December - 19 December 2024
-              </Text>
-            </Timeline.Item>
-          </Timeline>
-        </Grid.Col>
-      </Grid>
+        <Timeline.Item
+          title="Manchester"
+          bullet={<IconBriefcase size="1rem" />}
+        >
+          <Text c="dimmed" size="sm">
+            Christmas market and deciding to live together!
+          </Text>
+          <List>
+            <List.Item>Manchester</List.Item>
+          </List>
+          <Text size="xs" mt={4}>
+            12th December - 14th December 2022
+          </Text>
+        </Timeline.Item>
+      </Timeline>
     </>
   );
 }

--- a/tests/admin/00_admin_pages.spec.ts
+++ b/tests/admin/00_admin_pages.spec.ts
@@ -19,13 +19,22 @@ test("Can sign in and navigate admin", async ({ page }) => {
   await page.getByRole("link", { name: "Admin stuff" }).click();
 
   await expect(page).toHaveTitle("Admin | Almost Yellow");
-  await expect(page.locator("h1")).toContainText("Welcome to our admin page");
+  await expect(page.locator("h1")).toContainText("Admin");
   await expect(page.getByRole("button", { name: "Sign out" })).toBeVisible();
 
   await page.getByRole("link", { name: "Chopin Liszt" }).click();
   await expect(page).toHaveURL("/admin/chopinliszt");
   await expect(page).toHaveTitle("Chopin Liszt | Almost Yellow");
   await expect(page.locator("h1")).toContainText("Chopin Liszt");
+
+  await page.getByRole("link", { name: "Admin" }).click();
+  await expect(page).toHaveURL("/admin");
+  await expect(page).toHaveTitle("Admin | Almost Yellow");
+
+  await page.getByRole("link", { name: "Our Holidays!" }).click();
+  await expect(page).toHaveURL("/admin/holidays");
+  await expect(page).toHaveTitle("Holidays | Almost Yellow");
+  await expect(page.locator("h1")).toContainText("Our trips and holidays");
 
   await page.getByRole("link", { name: "Admin" }).click();
   await expect(page).toHaveURL("/admin");
@@ -51,6 +60,15 @@ test("Redirected to login if tried to get to admin pages while not signed in", a
   await page.goto("/admin/chopinliszt");
   await expect(page).toHaveURL(
     "http://localhost:3000/admin/login?callbackUrl=http%3A%2F%2Flocalhost%3A3000%2Fadmin%2Fchopinliszt",
+  );
+  await expect(page).toHaveTitle("Login | Almost Yellow");
+  await expect(page.locator("h1")).toContainText(
+    "Want to access the good stuff?",
+  );
+
+  await page.goto("/admin/holidays");
+  await expect(page).toHaveURL(
+    "http://localhost:3000/admin/login?callbackUrl=http%3A%2F%2Flocalhost%3A3000%2Fadmin%2Fholidays",
   );
   await expect(page).toHaveTitle("Login | Almost Yellow");
   await expect(page.locator("h1")).toContainText(

--- a/tests/public/00_initial_load.spec.ts
+++ b/tests/public/00_initial_load.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from "@playwright/test";
 
-test('Homepage has the title "Almost yellow"', async ({ page }) => {
+test('Homepage has the title "Almost Yellow"', async ({ page }) => {
   await page.goto("/");
   // Check the h1 exists
-  await expect(page.locator("h1")).toContainText("Almost yellow");
+  await expect(page.locator("h1")).toContainText("Almost Yellow");
   // Check the overall website title exists
   await expect(page).toHaveTitle("Almost Yellow");
 });

--- a/tests/public/01_navigation.spec.ts
+++ b/tests/public/01_navigation.spec.ts
@@ -28,19 +28,25 @@ test("Can navigate to the games page and through its subpages", async ({
   await expect(page).toHaveURL("/games/irishbingo");
   await expect(page.locator("h1")).toContainText("Irish Bingo");
 
-  await page.getByRole("link", { name: "Games" }).click();
+  await page.getByLabel("Back to our games list").click();
   await page.getByRole("link", { name: "Uno" }).click();
   await expect(page).toHaveTitle("Uno | Almost Yellow");
   await expect(page).toHaveURL("/games/uno");
   await expect(page.locator("h1")).toContainText("Uno");
 
-  await page.getByRole("link", { name: "Games" }).click();
+  await page.getByLabel("Back to our games list").click();
   await page.getByRole("link", { name: "Snakes and Ladders" }).click();
   await expect(page).toHaveTitle("Snakes and Ladders | Almost Yellow");
   await expect(page).toHaveURL("/games/snakesandladders");
   await expect(page.locator("h1")).toContainText("Snakes");
 
-  await page.getByRole("link", { name: "Games" }).click();
+  await page.getByLabel("Back to our games list").click();
+  await page.getByRole("link", { name: "Boom Boom Pirate" }).click();
+  await expect(page).toHaveTitle("Boom Boom Pirate | Almost Yellow");
+  await expect(page).toHaveURL("/games/boomboompirate");
+  await expect(page.locator("h1")).toContainText("Boom");
+
+  await page.getByLabel("Back to our games list").click();
   await page.getByRole("link", { name: "Home" }).click();
   await expect(page).toHaveURL("/");
   await expect(page).toHaveTitle("Almost Yellow");
@@ -66,14 +72,6 @@ test("Navigate to the holidays page", async ({ page }) => {
   await expect(page).toHaveURL("/holidays");
   await expect(page).toHaveTitle("Holidays | Almost Yellow");
   await expect(page.locator("h1")).toContainText("Our trips and holidays");
-
-  await page.getByRole("link", { name: "Home" }).click();
-  await expect(page).toHaveURL("/");
-  await expect(page).toHaveTitle("Almost Yellow");
-});
-
-test("Jumping to home from 3 layer breadcrumb", async ({ page }) => {
-  await page.goto("/games/irishbingo");
 
   await page.getByRole("link", { name: "Home" }).click();
   await expect(page).toHaveURL("/");

--- a/tests/public/01_navigation.spec.ts
+++ b/tests/public/01_navigation.spec.ts
@@ -64,16 +64,3 @@ test("Navigate to the decision maker page", async ({ page }) => {
   await expect(page).toHaveURL("/");
   await expect(page).toHaveTitle("Almost Yellow");
 });
-
-test("Navigate to the holidays page", async ({ page }) => {
-  await page.goto("/");
-
-  await page.getByRole("link", { name: "Our holidays!" }).click();
-  await expect(page).toHaveURL("/holidays");
-  await expect(page).toHaveTitle("Holidays | Almost Yellow");
-  await expect(page.locator("h1")).toContainText("Our trips and holidays");
-
-  await page.getByRole("link", { name: "Home" }).click();
-  await expect(page).toHaveURL("/");
-  await expect(page).toHaveTitle("Almost Yellow");
-});


### PR DESCRIPTION
## Overview of changes

Some quick tidy up things to improve usability, including:

- Add thinking time to decision maker
- Make a new back button to replace breadcrumbs so games are more mobile friendly
- Tidy up irish bingo page and add instructions modal
- Change the cocktails page back to using a dropdown
- Moved the holidays page back to admin and centred timeline
- Spruced up the admin page

## Checklist

- [x] I have tested these changes locally using `pnpm test`
- [ ] I have updated the documentation (if needed)
- [x] I have added or updated tests for these changes (if applicable)

## Reviewer instructions

Nothing specific
