### PR TITLE
Add skip to main content link

### DIFF
--- a/src/app/(homepage)/page.tsx
+++ b/src/app/(homepage)/page.tsx
@@ -4,7 +4,6 @@ import {
   IconMoodPuzzled,
   IconCheese,
   IconGlassCocktail,
-  IconBeach,
   IconPaperclip,
 } from "@tabler/icons-react";
 import Header from "@/components/header";
@@ -15,7 +14,7 @@ export default function Home() {
     <>
       <Header noCrumbs={true} />
 
-      <main>
+      <main id="main-content">
         <Title className={styles.gradient} ta="center">
           Almost Yellow
         </Title>

--- a/src/app/admin/(admin)/page.tsx
+++ b/src/app/admin/(admin)/page.tsx
@@ -18,7 +18,7 @@ export default function Admin() {
     <>
       <Header crumbs={crumbitems} />
 
-      <main>
+      <main id="main-content">
         <Title ta="center">Admin</Title>
 
         <Space h="xl" />

--- a/src/app/admin/chopinliszt/page.tsx
+++ b/src/app/admin/chopinliszt/page.tsx
@@ -18,7 +18,7 @@ export default async function ChopinLiszt() {
     <>
       <Header crumbs={crumbitems} />
 
-      <main>
+      <main id="main-content">
         <Container size="lg">
           <Title mb="xl">Our Chopin Liszt</Title>
           <Checklist />

--- a/src/app/admin/holidays/page.tsx
+++ b/src/app/admin/holidays/page.tsx
@@ -19,7 +19,7 @@ export default function HolidaysPage() {
     <>
       <Header crumbs={crumbitems} />
 
-      <main>
+      <main id="main-content">
         <Container size="xs">
           <Title>Our trips and holidays</Title>
           <HolidayTimeline />

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -11,7 +11,7 @@ export default function Login() {
     <>
       <Header noCrumbs={true} />
 
-      <main>
+      <main id="main-content">
         <LoginForm />
       </main>
     </>

--- a/src/app/cocktails/page.tsx
+++ b/src/app/cocktails/page.tsx
@@ -23,7 +23,7 @@ export default function CocktailsPage() {
     <>
       <Header crumbs={crumbitems} />
 
-      <main>
+      <main id="main-content">
         <Container size="lg">
           <Title>Cocktails</Title>
           <Cocktails />

--- a/src/app/decisionmaker/page.tsx
+++ b/src/app/decisionmaker/page.tsx
@@ -22,7 +22,7 @@ export default function DecisionMakerPage() {
     <>
       <Header crumbs={crumbitems} />
 
-      <main>
+      <main id="main-content">
         <Title>The Decision Maker</Title>
         <Space h="xl" />
         <DecisionMaker />

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -19,7 +19,7 @@ export default function Error({
     <>
       <Header noCrumbs={true} />
 
-      <main>
+      <main id="main-content">
         <Container size="xs">
           <Stack gap="xl">
             <Title ta="center">Something went very wrong!</Title>

--- a/src/app/games/(games)/page.tsx
+++ b/src/app/games/(games)/page.tsx
@@ -22,7 +22,7 @@ export default async function Games() {
     <>
       <Header crumbs={crumbitems} />
 
-      <main>
+      <main id="main-content">
         <Title>Our games</Title>
         <Space h="xl" />
 

--- a/src/app/games/boomboompirate/page.tsx
+++ b/src/app/games/boomboompirate/page.tsx
@@ -17,7 +17,7 @@ export default function BoomBoomPiratePage() {
     <>
       <Header noCrumbs={true} game={true} />
 
-      <main>
+      <main id="main-content">
         <Title>Boom Boom Pirate</Title>
         <Space h="xl" />
         <BoomBoomPirate />

--- a/src/app/games/irishbingo/page.tsx
+++ b/src/app/games/irishbingo/page.tsx
@@ -16,7 +16,7 @@ export default function IrishBingoPage() {
     <>
       <Header noCrumbs={true} game={true} />
 
-      <main>
+      <main id="main-content">
         <IrishBingo />
       </main>
     </>

--- a/src/app/games/snakesandladders/page.tsx
+++ b/src/app/games/snakesandladders/page.tsx
@@ -18,7 +18,7 @@ export default function SnakesAndLaddersPage() {
     <>
       <Header noCrumbs={true} game={true} />
 
-      <main>
+      <main id="main-content">
         <Title>Snakes and Ladders</Title>
         <Space h="xl" />
         <SnakesAndLadders />

--- a/src/app/games/uno/page.tsx
+++ b/src/app/games/uno/page.tsx
@@ -11,7 +11,7 @@ export default async function UnoPage() {
     <>
       <Header noCrumbs={true} game={true} />
 
-      <main>
+      <main id="main-content">
         <Title>Uno</Title>
         <Text>Under construction...</Text>
       </main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,17 @@
 import "@mantine/core/styles.css";
-import { MantineProvider, ColorSchemeScript, AppShell } from "@mantine/core";
+import {
+  MantineProvider,
+  ColorSchemeScript,
+  AppShell,
+  Anchor,
+} from "@mantine/core";
 import { acalat } from "@/styles/acalat";
 import "@/styles/global.css";
 import type { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import Script from "next/script";
+import skip from "@/styles/skip.module.css";
 
 export const metadata: Metadata = {
   title: {
@@ -59,6 +65,9 @@ export default function RootLayout({
             header={{ height: { base: 60, md: 70, lg: 80 } }}
             padding="md"
           >
+            <Anchor href="#main-content" className={skip.skiplink}>
+              Skip to main content
+            </Anchor>
             {children}
           </AppShell>
           <Analytics />

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -6,7 +6,7 @@ export default function NotFound() {
     <>
       <Header noCrumbs={true} />
 
-      <main>
+      <main id="main-content">
         <Container size="xs">
           <Stack gap="xl">
             <Title ta="center">Page not found (404)</Title>

--- a/src/components/decisionmaker.tsx
+++ b/src/components/decisionmaker.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { Textarea, Button, SimpleGrid, Stack, Text } from "@mantine/core";
+import {
+  Textarea,
+  Button,
+  SimpleGrid,
+  Stack,
+  Text,
+  Group,
+} from "@mantine/core";
 import { useForm, Form } from "@mantine/form";
 import classes from "@/styles/textarea.module.css";
 import playConfetti from "@/components/playconfetti";
@@ -46,9 +53,45 @@ export default function DecisionMaker() {
     }, 3000);
   };
 
+  const prePopulateTakeaways = () => {
+    const prepopulatedTakeaways = `KFC
+McDonalds
+Nandos
+Subway
+Dominos
+Bella Italia
+Picco
+Shake n Cake
+Toby Carvery
+North Road Fish Bar
+New Leung Kee
+Star of Bengal
+Bombay Gate
+Manjaros
+Santorini`;
+
+    form.setFieldValue("options", prepopulatedTakeaways);
+  };
+
+  const prePopulateNames = () => {
+    const prepopulatedNames = `Cam
+Laura`;
+
+    form.setFieldValue("options", prepopulatedNames);
+  };
+
   return (
     <SimpleGrid spacing="xl" cols={{ base: 1, sm: 2 }}>
       <Form form={form} onSubmit={makeDecision}>
+        <Group>
+          <Button mb="md" variant="default" onClick={prePopulateTakeaways}>
+            Darlington Takeaways
+          </Button>
+          <Button mb="md" variant="default" onClick={prePopulateNames}>
+            Our names
+          </Button>
+        </Group>
+
         <Textarea
           classNames={{ label: classes.label, input: classes.input }}
           label="List out your options"

--- a/src/styles/skip.module.css
+++ b/src/styles/skip.module.css
@@ -1,0 +1,37 @@
+.skiplink {
+  background-color: #e8590c;
+  color: #000000;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: 100px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  -webkit-user-select: none;
+  user-select: none;
+  text-decoration: underline;
+  text-decoration-thickness: max(1px, 0.0625rem);
+  text-underline-offset: 0.1578em;
+  font-size: 0.875rem;
+  line-height: 1.1428571429;
+  display: block;
+  padding: 10px 15px;
+}
+
+.skiplink:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: inherit;
+  overflow: visible;
+  clip: auto;
+  -webkit-clip-path: none;
+  clip-path: none;
+  white-space: inherit;
+  -webkit-user-select: text;
+  user-select: text;
+  margin-bottom: 20px;
+}


### PR DESCRIPTION
## Overview of changes

Adds a skip to main content link to help with keyboard navigation, skipping the breadcrumbs, navigation and header links.

Hidden by default, but is the first thing tabbed to on a keyboard and looks like this when active

![image](https://github.com/user-attachments/assets/cd582e53-dcee-4b54-9058-0a2c3760b1c6)

![image](https://github.com/user-attachments/assets/10eb328e-4ef5-4111-b822-8274495b595c)

## Checklist

- [x] I have tested these changes locally using `pnpm test`
- [ ] I have updated the documentation (if needed)
- [ ] I have added or updated tests for these changes (if applicable)

## Reviewer instructions

Load the page and hit tab, you should be able to see it, if you hit enter to then move the focus past all the header links.