### PR TITLE
add film and whisky search and loading message to chopin liszt

### DIFF
--- a/src/components/chopinliszt.tsx
+++ b/src/components/chopinliszt.tsx
@@ -9,6 +9,7 @@ import {
   Space,
   Group,
   ActionIcon,
+  Text,
 } from "@mantine/core";
 import { IconTrash } from "@tabler/icons-react";
 import { useDisclosure } from "@mantine/hooks";
@@ -27,7 +28,7 @@ export interface Item {
 
 const ChopinLiszt: React.FC = () => {
   const [modalOpened, { open, close }] = useDisclosure(false);
-
+  const [loading, setLoading] = useState(true);
   const [items, setItems] = useState<Item[]>([]);
   const [newItemText, setNewItemText] = useState("");
 
@@ -41,6 +42,7 @@ const ChopinLiszt: React.FC = () => {
       const data = await readChopin();
       console.log("Data fetch successful");
       setItems(data);
+      setLoading(false);
     } catch (error) {
       console.error("Error fetching data:", error);
     }
@@ -93,6 +95,10 @@ const ChopinLiszt: React.FC = () => {
       console.error("Error deleting item:", error);
     }
   };
+
+  if (loading) {
+    return <Text>Fetching list...</Text>;
+  }
 
   return (
     <>

--- a/src/components/cocktails.tsx
+++ b/src/components/cocktails.tsx
@@ -1,10 +1,17 @@
 "use client";
 
-import { NativeSelect, Space } from "@mantine/core";
+import {
+  NativeSelect,
+  Space,
+  TextInput,
+  ActionIcon,
+  Group,
+} from "@mantine/core";
 import { useState } from "react";
 import { cocktaildata } from "@/components/cocktaildata";
 import styles from "@/styles/cocktails.module.css";
 import CocktailBox from "@/components/cocktailbox";
+import { IconX } from "@tabler/icons-react";
 
 interface Cocktail {
   name: string;
@@ -25,6 +32,11 @@ const uniqueSpirits = [
 
 export default function Cocktails() {
   const [selectedSpirits, setSelectedSpirits] = useState<string[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(event.target.value);
+  };
 
   const handleChange = (value: string) => {
     setSelectedSpirits(value === "All spirits" ? [] : [value]);
@@ -37,20 +49,45 @@ export default function Cocktails() {
     );
   });
 
+  const searchedCocktails = filteredCocktails.filter((cocktail) =>
+    cocktail.name.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
+
   return (
     <>
-      <Space h="md" />
-      <NativeSelect
-        aria-label="Filter by base spirit"
-        value={
-          selectedSpirits.length === 0 ? "All spirits" : selectedSpirits[0]
-        }
-        onChange={(event) => handleChange(event.target.value)}
-        data={uniqueSpirits}
-      />
-      <Space h="md" />
+      <Group my="md">
+        <NativeSelect
+          aria-label="Filter by base spirit"
+          value={
+            selectedSpirits.length === 0 ? "All spirits" : selectedSpirits[0]
+          }
+          onChange={(event) => handleChange(event.target.value)}
+          data={uniqueSpirits}
+          style={{ minWidth: 200 }}
+        />
+
+        <TextInput
+          aria-label="Search cocktail names"
+          placeholder="Search cocktail names..."
+          value={searchQuery}
+          onChange={handleSearch}
+          style={{ flex: 1, minWidth: 200 }}
+          rightSection={
+            searchQuery && (
+              <ActionIcon
+                onClick={() => setSearchQuery("")}
+                variant="default"
+                aria-label="Clear search query"
+              >
+                <IconX />
+              </ActionIcon>
+            )
+          }
+        />
+      </Group>
+
       <div className={styles.cocktailList}>
-        {filteredCocktails
+        {searchedCocktails
           .sort((a, b) => a.name.localeCompare(b.name)) // Sort alphabetically
           .map((cocktail) => (
             <div key={cocktail.name} className={styles.cocktailCard}>

--- a/src/components/cocktails.tsx
+++ b/src/components/cocktails.tsx
@@ -2,7 +2,7 @@
 
 import {
   NativeSelect,
-  Space,
+  Text,
   TextInput,
   ActionIcon,
   Group,
@@ -85,6 +85,10 @@ export default function Cocktails() {
           }
         />
       </Group>
+
+      <Text m="xs">
+        Showing {searchedCocktails.length} of {cocktaildata.length} cocktails
+      </Text>
 
       <div className={styles.cocktailList}>
         {searchedCocktails

--- a/src/components/filmlist.tsx
+++ b/src/components/filmlist.tsx
@@ -8,6 +8,7 @@ import {
   Accordion,
   Stack,
   Progress,
+  TextInput,
 } from "@mantine/core";
 import { FilmCard, Film } from "@/components/filmcard";
 import { useState, useEffect } from "react";
@@ -65,6 +66,16 @@ export default function FilmList() {
     }
   });
 
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(event.target.value);
+  };
+
+  const searchedFilmData = sortedFilmData.filter((film) =>
+    film.name.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
+
   const imdbOptions = [
     { value: "true", label: "Top 30" },
     { value: "false", label: "Not top 30" },
@@ -83,6 +94,7 @@ export default function FilmList() {
     setWatchedFilter(null);
     setJarFilter(null);
     setSortOption("alphabetical");
+    setSearchQuery("");
   };
 
   const sortOptions = [
@@ -95,14 +107,14 @@ export default function FilmList() {
     return <Text>Fetching list...</Text>;
   }
 
-  const film_count = filteredFilmData.length;
-  const watched_film_count = filteredFilmData.filter(
+  const film_count = searchedFilmData.length;
+  const watched_film_count = searchedFilmData.filter(
     (film) => film.watched,
   ).length;
   const watched_film_percentage = (watched_film_count / film_count) * 100;
 
   const copyToClipboard = () => {
-    const filmNameList = sortedFilmData
+    const filmNameList = searchedFilmData
       .map((film) => `${film.name} (${film.release_year})`)
       .join("\n");
     clipboard.copy(filmNameList);
@@ -111,7 +123,7 @@ export default function FilmList() {
   const downloadCSV = () => {
     const csvContent = [
       ["Name", "Release Year", "Watched", "Top 30", "In Jar"],
-      ...sortedFilmData.map((film) => [
+      ...searchedFilmData.map((film) => [
         `"${film.name.replace(/"/g, '""')}"`,
         film.release_year,
         film.watched ? "Yes" : "No",
@@ -209,29 +221,36 @@ export default function FilmList() {
         />
       </Stack>
 
-      <Group justify="flex-end" mb="lg">
-        <Button
-          onClick={() => {
-            copyToClipboard();
-            setTimeout(() => clipboard.reset(), 500);
-          }}
-          size="md"
-          variant="default"
-          leftSection={<IconCopy />}
-        >
-          {clipboard.copied ? "Copied" : "Copy film names to clipboard"}
-        </Button>
-        <Button
-          onClick={downloadCSV}
-          size="md"
-          variant="default"
-          leftSection={<IconDownload />}
-        >
-          Download CSV
-        </Button>
+      <Group mb="md" justify="space-between">
+        <TextInput
+          aria-label="Search film titles"
+          placeholder="Search film titles..."
+          value={searchQuery}
+          onChange={handleSearch}
+          style={{ flex: 1 }}
+        />
+        <Group>
+          <Button
+            onClick={() => {
+              copyToClipboard();
+              setTimeout(() => clipboard.reset(), 500);
+            }}
+            variant="default"
+            leftSection={<IconCopy />}
+          >
+            {clipboard.copied ? "Copied" : "Copy film names to clipboard"}
+          </Button>
+          <Button
+            onClick={downloadCSV}
+            variant="default"
+            leftSection={<IconDownload />}
+          >
+            Download CSV
+          </Button>
+        </Group>
       </Group>
 
-      {sortedFilmData.map((film) => (
+      {searchedFilmData.map((film) => (
         <div key={film.id}>
           <FilmCard {...film} />
         </div>

--- a/src/components/filmlist.tsx
+++ b/src/components/filmlist.tsx
@@ -9,13 +9,14 @@ import {
   Stack,
   Progress,
   TextInput,
+  ActionIcon,
 } from "@mantine/core";
 import { FilmCard, Film } from "@/components/filmcard";
 import { useState, useEffect } from "react";
 import BackToTop from "@/components/backtotop";
 import { readFilmList } from "@/services/filmlist";
 import { useClipboard } from "@mantine/hooks";
-import { IconCopy, IconDownload } from "@tabler/icons-react";
+import { IconCopy, IconDownload, IconX } from "@tabler/icons-react";
 
 export default function FilmList() {
   const clipboard = useClipboard({ timeout: 500 });
@@ -228,7 +229,19 @@ export default function FilmList() {
           value={searchQuery}
           onChange={handleSearch}
           style={{ flex: 1 }}
+          rightSection={
+            searchQuery && (
+              <ActionIcon
+                onClick={() => setSearchQuery("")}
+                variant="default"
+                aria-label="Clear search query"
+              >
+                <IconX />
+              </ActionIcon>
+            )
+          }
         />
+
         <Group>
           <Button
             onClick={() => {

--- a/src/components/whiskyjournal.tsx
+++ b/src/components/whiskyjournal.tsx
@@ -14,7 +14,6 @@ import { IconX } from "@tabler/icons-react";
 import { WhiskyCard } from "@/components/whiskycard";
 import BackToTop from "@/components/backtotop";
 import { readWhiskyJournal } from "@/services/whiskyjournal";
-import { set } from "zod";
 
 export interface Whisky {
   last_edited: Date;

--- a/src/components/whiskyjournal.tsx
+++ b/src/components/whiskyjournal.tsx
@@ -1,10 +1,20 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Select, Button, Group, Text, Accordion } from "@mantine/core";
+import {
+  Select,
+  Button,
+  Group,
+  Text,
+  Accordion,
+  TextInput,
+  ActionIcon,
+} from "@mantine/core";
+import { IconX } from "@tabler/icons-react";
 import { WhiskyCard } from "@/components/whiskycard";
 import BackToTop from "@/components/backtotop";
 import { readWhiskyJournal } from "@/services/whiskyjournal";
+import { set } from "zod";
 
 export interface Whisky {
   last_edited: Date;
@@ -50,6 +60,11 @@ export default function WhiskyJournal() {
     null,
   );
   const [sortOption, setSortOption] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(event.target.value);
+  };
 
   const filteredWhiskyData = whiskies.filter((whisky) => {
     return (
@@ -84,20 +99,24 @@ export default function WhiskyJournal() {
     }
   });
 
+  const searchedWhiskyData = sortedWhiskyData.filter((whisky) =>
+    whisky.name.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
+
   const grainOptions = Array.from(
-    new Set(whiskyData.map((whisky) => whisky.grain)),
+    new Set(searchedWhiskyData.map((whisky) => whisky.grain)),
   ).sort();
 
   const distilleryOptions = Array.from(
-    new Set(whiskyData.map((whisky) => whisky.distillery)),
+    new Set(searchedWhiskyData.map((whisky) => whisky.distillery)),
   ).sort();
 
   const ratingOptions = Array.from(
-    new Set(whiskyData.map((whisky) => whisky.rating.toString())),
+    new Set(searchedWhiskyData.map((whisky) => whisky.rating.toString())),
   ).sort((a, b) => parseFloat(a) - parseFloat(b));
 
   const countryRegionOptions = Array.from(
-    new Set(whiskyData.map((whisky) => whisky.country_region)),
+    new Set(searchedWhiskyData.map((whisky) => whisky.country_region)),
   ).sort();
 
   const clearAllFilters = () => {
@@ -107,6 +126,7 @@ export default function WhiskyJournal() {
     setPriceFilter(null);
     setCountryRegionFilter(null);
     setSortOption(null);
+    setSearchQuery("");
   };
 
   const sortOptions = [
@@ -191,7 +211,31 @@ export default function WhiskyJournal() {
         </Accordion.Item>
       </Accordion>
 
-      {sortedWhiskyData.map((whisky) => (
+      <TextInput
+        mb="md"
+        aria-label="Search whisky names"
+        placeholder="Search whisky names..."
+        value={searchQuery}
+        onChange={handleSearch}
+        style={{ flex: 1 }}
+        rightSection={
+          searchQuery && (
+            <ActionIcon
+              onClick={() => setSearchQuery("")}
+              variant="default"
+              aria-label="Clear search query"
+            >
+              <IconX />
+            </ActionIcon>
+          )
+        }
+      />
+
+      <Text m="sm">
+        Showing {searchedWhiskyData.length} of {whiskyData.length} whiskies
+      </Text>
+
+      {searchedWhiskyData.map((whisky) => (
         <div key={whisky.whisky_id}>
           <WhiskyCard {...whisky} />
         </div>

--- a/tests/public-database/01_whiskyjournal.spec.ts
+++ b/tests/public-database/01_whiskyjournal.spec.ts
@@ -35,3 +35,25 @@ test("Whisky Journal Page Test", async ({ page }) => {
     /Johnnie Walker Black Label/,
   );
 });
+
+test("Can search whiskies by name", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("link", { name: "Cam's whisky journal" }).click();
+  await page.fill('input[placeholder="Search whisky names..."]', "Talisker");
+
+  await expect(page.locator("#main-content")).toContainText(
+    /Talisker 10 Year Old/,
+  );
+  await expect(page.locator("#main-content")).not.toContainText(
+    /Johnnie Walker Black Label/,
+  );
+
+  // Clear search and check both whiskies are there
+  await page.click('button[aria-label="Clear search query"]');
+  await expect(page.locator("#main-content")).toContainText(
+    /Talisker 10 Year Old/,
+  );
+  await expect(page.locator("#main-content")).toContainText(
+    /Johnnie Walker Black Label/,
+  );
+});

--- a/tests/public-database/02_filmlist.spec.ts
+++ b/tests/public-database/02_filmlist.spec.ts
@@ -64,3 +64,20 @@ test("Download CSV and check contents", async ({ page }) => {
 
   expect(rows.length).toBeGreaterThan(50);
 });
+
+test("Can search films by name", async ({ page }) => {
+  await page.goto("/films");
+  await page.fill('input[placeholder="Search film titles..."]', "Seven");
+
+  await expect(page.locator("#main-content")).toContainText(/Seven Samurai/);
+  await expect(page.locator("#main-content")).not.toContainText(
+    /Final Destination/,
+  );
+
+  // Clear search and check both films are there
+  await page.click('button[aria-label="Clear search query"]');
+  await expect(page.locator("#main-content")).toContainText(/Seven Samurai/);
+  await expect(page.locator("#main-content")).toContainText(
+    /Final Destination/,
+  );
+});

--- a/tests/public/04_cocktails.spec.ts
+++ b/tests/public/04_cocktails.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+test("Can filter and search cocktails", async ({ page }) => {
+  await page.goto("/cocktails");
+
+  // Check that Bramble and Luigi are in the list
+  await expect(page.locator("text=Manhattan")).toBeVisible();
+  await expect(page.locator("text=Luigi")).toBeVisible();
+
+  // Filter by gin
+  await page.getByLabel("Filter by base spirit").selectOption("Gin");
+  await expect(page.locator("text=Manhattan")).not.toBeVisible();
+  await expect(page.locator("text=Luigi")).toBeVisible();
+
+  // Clear filter
+  await page.getByLabel("Filter by base spirit").selectOption("All spirits");
+
+  await expect(page.locator("text=Manhattan")).toBeVisible();
+  await expect(page.locator("text=Luigi")).toBeVisible();
+
+  // Search for Luigi
+  await page.getByPlaceholder("Search cocktail names...").fill("Luigi");
+  await expect(page.locator("text=Luigi")).toBeVisible();
+  await expect(page.locator("text=Manhattan")).not.toBeVisible();
+
+  // Clear search
+  await page.click('button[aria-label="Clear search query"]');
+  await expect(page.locator("text=Luigi")).toBeVisible();
+  await expect(page.locator("text=Manhattan")).toBeVisible();
+});


### PR DESCRIPTION
## Overview of changes

Adds a loading message to the chopin liszt so the time difference between the button and list is less confusing:

![image](https://github.com/user-attachments/assets/2083cce9-a66e-4607-8fa0-dcd2a8814b87)

And adds a basic search bar to the films list for easy finding of films

![image](https://github.com/user-attachments/assets/10c48b2a-fa47-47ef-a9a0-30d1f3289614)

While I was there, I also added a search to the whisky journal, and a count of the number of whiskies in the journal

![image](https://github.com/user-attachments/assets/09424570-dd1f-4dda-93bd-6554c7d751fb)

## Checklist

- [x] I have tested these changes locally using `pnpm test`
- [ ] I have updated the documentation (if needed)
- [x] I have added or updated tests for these changes (if applicable)

## Reviewer instructions

Nothing specific, just give it a quick check over.