### PR TITLE
update header to allow homepage only and add to the login page

### DIFF
--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 export default function Login() {
   return (
     <>
-      <Header noCrumbs={true} />
+      <Header noCrumbs={true} homeOnly={true} />
 
       <main id="main-content">
         <LoginForm />

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -16,12 +16,12 @@ import {
   IconChevronLeft,
   IconGlass,
   IconMovie,
+  IconHome,
 } from "@tabler/icons-react";
 import playConfetti from "@/components/playconfetti";
 import { IconMoon, IconSun } from "@tabler/icons-react";
 import cx from "clsx";
 import classes from "@/styles/togglecolour.module.css";
-import WhiskyJournal from "./whiskyjournal";
 
 interface BreadcrumbItem {
   title: string;
@@ -34,17 +34,19 @@ interface HeaderProps {
   game?: boolean; // Back button for our games pages
   whiskyJournal?: boolean; // Back button for our whisky journal pages
   filmList?: boolean; // Back button for our film list pages
+  homeOnly?: boolean; // Just show the home button
 }
 
 export default function Header({
   crumbs,
-  noCrumbs = false,
+  noCrumbs = false, // This needs to be set to true if you want to use any of the other buttons
   game = false,
   whiskyJournal = false,
   filmList = false,
+  homeOnly = false,
 }: HeaderProps) {
   const mainJustify =
-    noCrumbs && !game && !whiskyJournal && !filmList
+    noCrumbs && !game && !whiskyJournal && !filmList && !homeOnly
       ? "flex-end"
       : "space-between"; // This keeps the icon buttons on the right when there's no crumbs
   const { setColorScheme } = useMantineColorScheme();
@@ -65,6 +67,22 @@ export default function Header({
               ))}
             </Breadcrumbs>
           </Group>
+        )}
+
+        {homeOnly && (
+          <Tooltip label="Back to our homepage" openDelay={250}>
+            <ActionIcon
+              variant="default"
+              component="a"
+              href="/"
+              size="xl"
+              aria-label="Back to our homepage"
+              style={{ width: 70 }}
+            >
+              <IconChevronLeft />
+              <IconHome />
+            </ActionIcon>
+          </Tooltip>
         )}
 
         {game && (

--- a/tests/public/01_navigation.spec.ts
+++ b/tests/public/01_navigation.spec.ts
@@ -64,3 +64,20 @@ test("Navigate to the decision maker page", async ({ page }) => {
   await expect(page).toHaveURL("/");
   await expect(page).toHaveTitle("Almost Yellow");
 });
+
+test("Navigate to the login page and back", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("link", { name: "Admin stuff" }).click();
+  await expect(page).toHaveURL(
+    "/admin/login?callbackUrl=http%3A%2F%2Flocalhost%3A3000%2Fadmin",
+  );
+  await expect(page).toHaveTitle("Login | Almost Yellow");
+  await expect(page.locator("h1")).toContainText(
+    "Want to access the good stuff?",
+  );
+
+  await page.getByRole("link", { name: "Back to our homepage" }).click();
+  await expect(page).toHaveURL("/");
+  await expect(page).toHaveTitle("Almost Yellow");
+});


### PR DESCRIPTION
## Overview of changes

Quick one to add a button to go back to the homepage from the login page as I realised we didn't have one and I got stuck on the login page on our tablet.

Edited the existing header function to add in a homeOnly option that allows for this and added a quick test for it too.

## Checklist

- [x] I have tested these changes locally using `pnpm test`
- [ ] I have updated the documentation (if needed)
- [x] I have added or updated tests for these changes (if applicable)

## Reviewer instructions

Not a lot to test here, though this is what it looks like (before there was nothing in the top left of the page)

![image](https://github.com/user-attachments/assets/7d01e45c-47f7-426e-8bcc-1fcb25b4bf68)