### PR TITLE
change dependabot to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "monthly"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -16,4 +16,4 @@ updates:
     # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"


### PR DESCRIPTION
## Overview of changes

Now we've fixed the updates running and got the most recent PRs in, I've reduced the frequency back to monthly so it's not constantly raising updates.

## Checklist

- [x] I have tested these changes locally using `pnpm test`
- [ ] I have updated the documentation (if needed)
- [ ] I have added or updated tests for these changes (if applicable)

## Reviewer instructions

Nothing really needed for this.