### PR TITLE
add date to films CSV download

### DIFF
--- a/src/components/filmlist.tsx
+++ b/src/components/filmlist.tsx
@@ -139,7 +139,8 @@ export default function FilmList() {
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.setAttribute("href", url);
-    link.setAttribute("download", "films.csv");
+    const today = new Date().toISOString().split("T")[0];
+    link.setAttribute("download", `films_${today}.csv`);
     link.style.visibility = "hidden";
     document.body.appendChild(link);
     link.click();


### PR DESCRIPTION
## Overview of changes

Quick one that adds the date to the CSV download for the films list, matching what we do already in the whisky journal.

![image](https://github.com/user-attachments/assets/f329522b-0471-4973-a755-870068688bd3)

I occassionally use these as backups so saves me renaming them as I download.

## Checklist

- [x] I have tested these changes locally using `pnpm test`
- [ ] I have updated the documentation (if needed)
- [ ] I have added or updated tests for these changes (if applicable)

## Reviewer instructions

Nothing to add