### PR TITLE
Set explicit permissions on workflows 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Linting
+permissions:
+  contents: read
 on:
   push:
     branches: [main]

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/cjrace/almostyellow/security/code-scanning/1](https://github.com/cjrace/almostyellow/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, it primarily needs `contents: read` to access the repository's contents. Additional permissions can be added if required by specific steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
